### PR TITLE
clilpboard issue and message details encoding issue

### DIFF
--- a/src/Log2Console/Log/LogMessage.cs
+++ b/src/Log2Console/Log/LogMessage.cs
@@ -160,16 +160,31 @@ namespace Log2Console.Log
         public string GetMessageDetails()
         {
             var sb = new StringBuilder();
-            sb.Append(@"{\rtf1\ansi ");
-            foreach (var fieldType in UserSettings.Instance.MessageDetailConfiguration)
+
+            if (UserSettings.Instance.UseMsgDetailsRtf)
             {
-                var info = GetInformation(fieldType).Replace(@"\", @"\\").Replace("{", @"\{").Replace("}", @"\}");
-                sb.Append(@"\b " + fieldType.Field + @": \b0 ");
-                if (info.Length > 40)
-                    sb.Append(@" \line ");
-                sb.Append(info + @" \line ");
+                sb.Append(@"{\rtf1\ansi ");
+                foreach (var fieldType in UserSettings.Instance.MessageDetailConfiguration)
+                {
+                    var info = GetInformation(fieldType).Replace(@"\", @"\\").Replace("{", @"\{").Replace("}", @"\}");
+                    sb.Append(@"\b " + fieldType.Field + @": \b0 ");
+                    if (info.Length > 40)
+                        sb.Append(@" \line ");
+                    sb.Append(info + @" \line ");
+                }
+                sb.Append(@"}");
             }
-            sb.Append(@"}");
+            else
+            {
+                foreach (var fieldType in UserSettings.Instance.MessageDetailConfiguration)
+                {
+                    var info = GetInformation(fieldType);
+                    sb.Append(fieldType.Field + ": ");
+                    if (info.Length > 40)
+                        sb.AppendLine();
+                    sb.AppendLine(info);
+                }
+            }
             return sb.ToString();
         }
     }

--- a/src/Log2Console/MainForm.cs
+++ b/src/Log2Console/MainForm.cs
@@ -740,7 +740,8 @@ namespace Log2Console
 
 
                 logDetailTextBox.ForeColor = logMsgItem.Message.Level.Color;
-                logDetailTextBox.Rtf = sb.ToString();
+                if (UserSettings.Instance.UseMsgDetailsRtf) logDetailTextBox.Rtf = sb.ToString();
+                else logDetailTextBox.Text = sb.ToString();
 
                 OpenSourceFile(logMsgItem.Message.SourceFileName, logMsgItem.Message.SourceFileLineNr);
             }

--- a/src/Log2Console/MainForm.cs
+++ b/src/Log2Console/MainForm.cs
@@ -154,7 +154,7 @@ namespace Log2Console
         private const int SIZE_MINIMIZED = 1;
         /// <summary>
         /// Catch on minimize event
-        /// @author : Asbjørn Ulsberg -=|=- asbjornu@hotmail.com
+        /// @author : Asbjorn Ulsberg -=|=- asbjornu@hotmail.com
         /// </summary>
         /// <param name="msg"></param>
         protected override void WndProc(ref Message msg)

--- a/src/Log2Console/MainForm.cs
+++ b/src/Log2Console/MainForm.cs
@@ -945,7 +945,7 @@ namespace Log2Console
             if (String.IsNullOrEmpty(logDetailTextBox.Text))
                 return;
 
-            Clipboard.SetText(logDetailTextBox.Text);
+            Clipboard.SetDataObject(logDetailTextBox.Text, false, 5, 200);
         }
 
         private void aboutBtn_Click(object sender, EventArgs e)
@@ -1317,7 +1317,7 @@ namespace Log2Console
                     builder.AppendLine(logMsgItem.Message.ToString());
             }
 
-            Clipboard.SetText(builder.ToString());
+            Clipboard.SetDataObject(builder.ToString(), false, 5, 200);
         }
     }
 }

--- a/src/Log2Console/Settings/UserSettings.cs
+++ b/src/Log2Console/Settings/UserSettings.cs
@@ -104,6 +104,7 @@ namespace Log2Console.Settings
 
         private bool _msgDetailsProperties = false;
         private bool _msgDetailsException = true;
+        private bool _msgDetailsUseRtf = true;
 
         private LogLevelInfo _logLevelInfo;
         private List<IReceiver> _receivers = new List<IReceiver>();
@@ -406,6 +407,15 @@ namespace Log2Console.Settings
         {
             get { return _msgDetailsException; }
             set { _msgDetailsException = value; }
+        }
+
+        [Category("Message Details")]
+        [Description("Use the Rich Text Format")]
+        [DisplayName("Use Rtf")]
+        public bool UseMsgDetailsRtf
+        {
+            get { return _msgDetailsUseRtf; }
+            set { _msgDetailsUseRtf = value; }
         }
 
         [Category("Fonts")]


### PR DESCRIPTION
1. changed only one character not written in ANSI code in the Mainform.cs file.
2. Currently the Message Details Box is using RTF(RichTextFormat) and the encoding of it is ANSI. Korean, Japanese, and Chinese characters are broken in there. So I made a option enabling RTF or not in the setting page. When you don't use RTF, any character of any language is not broken. 
3. When coping a message to clipboard, sometimes an external exception occurs. To make it retry several times, I resolved the problem. I referred the solution on the stackoverflow(https://stackoverflow.com/questions/930219/how-to-handle-blocked-clipboard-and-other-oddities).
