### PR TITLE
show line breaks in RTF text box

### DIFF
--- a/src/Log2Console/Log/LogMessage.cs
+++ b/src/Log2Console/Log/LogMessage.cs
@@ -163,7 +163,7 @@ namespace Log2Console.Log
             sb.Append(@"{\rtf1\ansi ");
             foreach (var fieldType in UserSettings.Instance.MessageDetailConfiguration)
             {
-                var info = GetInformation(fieldType).Replace(@"\", @"\\").Replace("{", @"\{").Replace("}", @"\}");
+                var info = GetInformation(fieldType).Replace(@"\", @"\\").Replace("\r\n", @" \line ").Replace("\n", @" \line ").Replace("{", @"\{").Replace("}", @"\}");
                 sb.Append(@"\b " + fieldType.Field + @": \b0 ");
                 if (info.Length > 40)
                     sb.Append(@" \line ");


### PR DESCRIPTION
Hi,
I've noticed that Log2Console's RTF text box doesn't display messages with line breaks on multiple lines, so to this end I've made a change to replace "\r\n" and "\n" with "\line" in GetMessageDetails, which fixes the issue.
Just wondered if you'd like to merge it.

Thanks
Ben Taylor
