### PR TITLE
add --portable startparameter to make it portable

### DIFF
--- a/src/Log2Console/MainForm.cs
+++ b/src/Log2Console/MainForm.cs
@@ -85,7 +85,8 @@ namespace Log2Console
             _loggersPanelFloaty.Docking += OnFloatyDocking;
 
             // Settings
-            _firstStartup = !UserSettings.Load();
+            bool portableMode = Environment.GetCommandLineArgs().Contains("--portable");
+            _firstStartup = !UserSettings.Load(portableMode);
             if (_firstStartup)
             {
                 // Initialize default layout


### PR DESCRIPTION
Added the start parameter `--portable` to make the application "portable" (load UserSettings.dat from the startup path)